### PR TITLE
BXMSDOC-1827 updated main.adoc to fix sequece warnings

### DIFF
--- a/docs/product-user-guide/src/main/asciidoc/main.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/main.adoc
@@ -74,11 +74,11 @@ include::chap-management-console.adoc[leveloffset=+1]
 include::chap-graphic-resources.adoc[leveloffset=+1]
 
 // Appendices
-include::appe-process-elements.adoc[]
+include::appe-process-elements.adoc[leveloffset=+1]
 
-include::appe-service-tasks.adoc[]
+include::appe-service-tasks.adoc[leveloffset=+1]
 
-include::appe-simulation-data.adoc[]
+include::appe-simulation-data.adoc[leveloffset=+1]
 endif::BPMS[]
 
 ifdef::BRMS[]


### PR DESCRIPTION
Added [leveloffset=+1] to the appendix files in main.adoc to eleminate the sequence warnings.