### PR TITLE
BXMSDOC-1728 Doc Ability to Install and Support Business execution runtimes on EAP 7.x

### DIFF
--- a/docs/product-installation-guide/src/main/asciidoc/assembly_installing-on-eap.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/assembly_installing-on-eap.adoc
@@ -10,7 +10,7 @@ For information on how to install {EAP} 7.0.7 on your computer, see the https://
 include::eap-business-central-install-proc.adoc[leveloffset=+1]
 
 include::eap-execution-server-download-install-proc.adoc[leveloffset=+1]
-NOTE: This section describes configuring Business Central and the Execution Server in the same container. In production environments, they are usually run in different containers.
+NOTE: This section describes configuring Business Central and Execution Server in the same container. In production environments, they are usually run in different containers.
 
 include::eap-users-create-proc.adoc[leveloffset=+1]
 include::eap-execution-server-configure-proc.adoc[leveloffset=+1]

--- a/docs/product-installation-guide/src/main/asciidoc/eap-business-central-install-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/eap-business-central-install-proc.adoc
@@ -10,16 +10,14 @@ Business Central is a web console that enables you to perform the following task
 .Prerequisites
 * {EAP} 7.0.7 installed on your hard drive. The base directory of the EAP installation is referred to as `__EAP_HOME__`.
 * The following file, available from the site that contains this document:
-** Business Central:
-ifdef::BPMS[`jboss-bpmsuite-7.0.0.Beta02-business-central-eap7.zip`]
-ifdef::BRMS[`jboss-brms-7.0.0.Beta02-business-central-eap7.zip`]
++
+ifdef::BPMS[`jboss-bpmsuite-7.0.0.LA.ER3-collection.zip`]
+ifdef::BRMS[`jboss-brms-7.0.0.LA.ER3-collection.zip`]
 
 .Procedure
-. Extract the
-ifdef::BPMS[`jboss-bpmsuite-7.0.0.Beta02-business-central-eap7.zip`]
-ifdef::BRMS[`jboss-brms-7.0.0.Beta02-business-central-eap7.zip`]
-archive to an arbitrary directory, here referred to as `__TEMP_DIR__`.
-. Copy the contents of the `__TEMP_DIR__/jboss-eap-7.0/` directory into `__EAP_HOME__`. When asked to overwrite files or merge directories, select *Yes*.
+. Extract the `jboss-bpmsuite-7.0.0.LA.ER3-collection.zip` archive to a temporary directory. In the following examples this directory is called `__TEMP_DIR__`.
+. Extract the `jboss-bpmsuite-7.0-business-central-eap7.zip` file, available from the `jboss-bpmsuite-7.0.0.LA.ER3-collection` directory that you extracted in the previous step.
+. Copy the contents of the `__TEMP_DIR__/jboss-bpmsuite-7.0.0.LA.ER3-collection/jboss-bpmsuite-7.0-business-central-eap7/jboss-eap-7.0` directory to `__EAP_HOME__`. When asked to overwrite files or merge directories, select *Yes*.
 +
-WARNING: Ensure the names of the {PRODUCT} deployments you are copying do not collide with your existing deployments in the {EAP} instance.
+WARNING: Ensure the names of the {PRODUCT} deployments you are copying do not conflict with your existing deployments in the {EAP} instance.
 

--- a/docs/product-installation-guide/src/main/asciidoc/eap-execution-server-configure-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/eap-execution-server-configure-proc.adoc
@@ -17,10 +17,6 @@ Execution server installed in `__EAP_HOME__` as described in <<eap_execution_ser
    <property name="org.kie.server.controller.pwd" value="controllerUser1234;"/>
    <property name="org.kie.server.user" value="controllerUser"/>
    <property name="org.kie.server.pwd" value="controllerUser1234;"/>
-   <property name="org.kie.server.id" value="default-kieserver"/>
-   <property name="org.kie.server.persistence.dialect" value="org.hibernate.dialect.H2Dialect"/>
-   <property name="org.kie.executor.jms.queue" value="queue/KIE.SERVER.EXECUTOR"/>
-   <property name="org.kie.server.persistence.ds" value="java:jboss/datasources/ExampleDS"/>
 ----
 ifdef::BRMS[]
 // The module is only needed for BPM Suite

--- a/docs/product-installation-guide/src/main/asciidoc/eap-execution-server-configure-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/eap-execution-server-configure-proc.adoc
@@ -17,6 +17,7 @@ Execution server installed in `__EAP_HOME__` as described in <<eap_execution_ser
    <property name="org.kie.server.controller.pwd" value="controllerUser1234;"/>
    <property name="org.kie.server.user" value="controllerUser"/>
    <property name="org.kie.server.pwd" value="controllerUser1234;"/>
+   <property name="org.kie.server.id" value="default-kieserver"/>
 ----
 ifdef::BRMS[]
 // The module is only needed for BPM Suite

--- a/docs/product-installation-guide/src/main/asciidoc/eap-execution-server-download-install-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/eap-execution-server-download-install-proc.adoc
@@ -7,13 +7,15 @@ Execution Server provides the runtime environment for business assets and access
 .Prerequisites
 * {EAP} 7.0.7 installed on your hard drive. The base directory of the EAP installation is referred to as `__EAP_HOME__`.
 * The following file, which you should have received with this document:
-** Execution Server: `jboss-brms-bpmsuite-7.0.0.Beta02-execution-server-ee7.zip`
++
+ifdef::BPMS[`jboss-bpmsuite-7.0.0.LA.ER3-execution-server-ee7.zip`]
+ifdef::BRMS[`jboss-brms-7.0.0.LA.ER3-execution-server-ee7.zip`]
 
 .Procedure
-. Extract the `jboss-brms-bpmsuite-7.0.0.Beta02-execution-server-ee7.zip` archive to an arbitrary directory, here referred to as `__TEMP_DIR__`.
-. Copy the `__TEMP_DIR__/jboss-brms-bpmsuite-7.0.0.Beta02-execution-server-ee7/kie-execution-server.war` directory into `__EAP_HOME__/standalone/deployments/`.
+. Extract the `jboss-bpmsuite-7.0.0.LA.ER3-execution-server-ee7.zip` archive to a temporary directory. In the following examples this directory is called `__TEMP_DIR__`.
+. Copy the `__TEMP_DIR__/jboss-bpmsuite-7.0.0.LA.ER3-execution-server-ee7/jboss-bpmsuite-7.0-execution-server-ee7/kie-execution-server.war` directory to `__EAP_HOME__/standalone/deployments/`.
 +
-WARNING: Ensure the names of the {PRODUCT} deployments you are copying do not collide with your existing deployments in the {EAP} instance.
-. Copy the contents of the `__TEMP_DIR__/jboss-brms-bpmsuite-7.0.0.Beta02-execution-server-ee7/SecurityPolicy/` to `__EAP_HOME__/bin`. When asked to overwrite files, select *Yes*.
-. In the `__EAP_HOME__/standalone/deployments/` directory, create an empty file named `kie-execution-server.war.dodeploy`. This file ensures that the Execution Server is automatically deployed when the server starts.
+WARNING: Ensure the names of the {PRODUCT} deployments you are copying do not conflict with your existing deployments in the {EAP} instance.
+. Copy the contents of the `__TEMP_DIR__/jboss-bpmsuite-7.0.0.LA.ER3-execution-server-ee7/jboss-bpmsuite-7.0-execution-server-ee7/SecurityPolicy/` to `__EAP_HOME__/bin`. When asked to overwrite files, select *Yes*.
+. In the `__EAP_HOME__/standalone/deployments/` directory, create an empty file named `kie-execution-server.war.dodeploy`. This file ensures that Execution Server is automatically deployed when the server starts.
 


### PR DESCRIPTION
Jira is [here](https://issues.jboss.org/browse/BXMSDOC-1728).
Rendered doc is [here](http://file.ork.redhat.com/~emmurphy/BXMSDOC-1728/).


