### PR TITLE
BXMSDOC-1800 When installing kie-execution-server only, the server won't start

### DIFF
--- a/docs/product-installation-guide/src/main/asciidoc/eap-bxms-run-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/eap-bxms-run-proc.adoc
@@ -22,6 +22,14 @@ $ ./standalone.sh
 ----
 standalone.bat
 ----
++
+[NOTE]
+====
+If you deployed Execution Server without Business Central on EAP then you must use the following command to start EAP with the standalone-full profile:
+----
+$ /standalone.sh -c standalone-full.xml
+----
+====
 . In a web browser, open the URL `localhost:8080/business-central`.
 . Log in using the user name
 ifdef::BPMS[]

--- a/docs/product-installation-guide/src/main/asciidoc/eap-bxms-run-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/eap-bxms-run-proc.adoc
@@ -25,9 +25,17 @@ standalone.bat
 +
 [NOTE]
 ====
-If you deployed Execution Server without Business Central on EAP then you must use the following command to start EAP with the standalone-full profile:
+If you deployed Execution Server without Business Central on EAP then you must use one of the following commands to start EAP with the standalone-full profile.
+
+On Linux or Unix-based systems:
 ----
 $ /standalone.sh -c standalone-full.xml
+----
+
+On Windows:
+[source,bash]
+----
+standalone.bat -c standalone-full.xml
 ----
 ====
 . In a web browser, open the URL `localhost:8080/business-central`.


### PR DESCRIPTION
Added note to Running on EAP section.
The rendered doc is [here](http://file.ork.redhat.com/~emmurphy/BXMSDOC-1800/#running_on_eap).