### PR TITLE
BXMSDOC-2222 Install instructions on how to use and configure standalone decision central package are missing

### DIFF
--- a/docs/product-assembly_installing-dm-on-premise/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_installing-dm-on-premise/src/main/asciidoc/main.adoc
@@ -37,8 +37,8 @@ include::product-installation-guide/ba-dm-supported-component-versions-ref.adoc[
 include::product-installation-guide/install-download-proc.adoc[leveloffset=+2]
 include::product-installation-guide/assembly_installing-using-installer.adoc[leveloffset=+2]
 include::product-installation-guide/assembly_installing-on-eap-deployable.adoc[leveloffset=+2]
-include::product-installation-guide/install-dc-standalone-proc.adoc[leveloffset=+2]
-include::product-installation-guide/install-standalone-properties-con.adoc[leveloffset=+3]
+include::product-installation-guide/run-dc-standalone-proc.adoc[leveloffset=+2]
+include::product-installation-guide/run-standalone-properties-con.adoc[leveloffset=+3]
 
 == Installing supporting tools
 include::product-development-guide/maven-repo-using-con.adoc[leveloffset=+2]

--- a/docs/product-assembly_installing-dm-on-premise/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_installing-dm-on-premise/src/main/asciidoc/main.adoc
@@ -35,10 +35,10 @@ include::product-installation-guide/installing-con.adoc[leveloffset=+1]
 include::product-installation-guide/ba-dm-supported-component-versions-ref.adoc[leveloffset=+2]
 
 include::product-installation-guide/install-download-proc.adoc[leveloffset=+2]
-include::product-installation-guide/install-dc-standalone-proc.adoc[leveloffset=+2]
-include::product-installation-guide/install-standalone-properties-con.adoc[leveloffset=+3]
 include::product-installation-guide/assembly_installing-using-installer.adoc[leveloffset=+2]
 include::product-installation-guide/assembly_installing-on-eap-deployable.adoc[leveloffset=+2]
+include::product-installation-guide/install-dc-standalone-proc.adoc[leveloffset=+2]
+include::product-installation-guide/install-standalone-properties-con.adoc[leveloffset=+3]
 
 == Installing supporting tools
 include::product-development-guide/maven-repo-using-con.adoc[leveloffset=+2]

--- a/docs/product-installation-guide/src/main/asciidoc/install-dc-standalone-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/install-dc-standalone-proc.adoc
@@ -29,6 +29,10 @@ swarm:
           plain-text: true
         properties-authorization:
           path: /path/to/application-roles.properties
+datasource:
+  management:
+    wildfly:
+      admin: admin
 ----
 . Create the `application-users.properties` file. Include an adminitrative user and if this {CENTRAL} instance will be a controller for {KIE_SERVER}, include a controller user, for example:
 +

--- a/docs/product-installation-guide/src/main/asciidoc/install-dc-standalone-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/install-dc-standalone-proc.adoc
@@ -1,21 +1,43 @@
 [id='install-dc-standalone-proc']
 = Installing standalone {CENTRAL} 
 
-You can use the {CENTRAL} standalone JAR file to install {CENTRAL} in a WildFly Swarm environment. This installation method does not require a separate server installation.
+You can use the {CENTRAL} standalone JAR file to install {CENTRAL} on an application server other than {EAP}. This installation method does not require a separate server installation.
+
+[NOTE]
+====
+Red Hat only supports this installation type when it is installed on premise, on Red Hat Enterprise Linux.
+//Any particular version of RHEL?
+====
 
 .Procedure
 
 . Download the {CENTRAL} standalone JAR file from the https://access.redhat.com[Red Hat Customer Portal].
-. Create a `yaml` configuration file as described in http://docs.wildfly-swarm.io/2017.12.1/#configuring-an-application-using-yaml[WildFly Swarm Documentation].
-. In a terminal window, navigate to the directory where you downloaded the installer file and enter the following command:
+. In a terminal window, navigate to the directory where you downloaded the installer file.
+. Create the `application-config.yaml` configuration file with the following contents:
++
+[source]
+----
+swarm:
+  management:
+    security-realms:
+      ApplicationRealm:
+        local-authentication:
+          default-user: local
+          allowed-users: local
+          skip-group-loading: true
+        properties-authentication:
+          path: /path/to/application-users.properties
+          plain-text: true
+        properties-authorization:
+          path: /path/to/application-roles.properties
+----
+Enter the following command:
 +
 [source]
 ----
 java -jar rhdm-7.0.0.GA-decision-central-standalone.jar -s
 application-config.yaml
 ----
-+
-In this command, `application-config.yaml` is the `yaml` configuration file that you created in step 2.
 
 In addition, you can set any properties supported by {CENTRAL} by including the `-D<property>=<value>` parameter in the installation command, for example:
 [source]

--- a/docs/product-installation-guide/src/main/asciidoc/install-dc-standalone-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/install-dc-standalone-proc.adoc
@@ -34,7 +34,7 @@ datasource:
     wildfly:
       admin: admin
 ----
-. Create the `application-users.properties` file. Include an adminitrative user and if this {CENTRAL} instance will be a controller for {KIE_SERVER}, include a controller user, for example:
+. Create the `application-users.properties` file. Include an administrative user and if this {CENTRAL} instance will be a controller for {KIE_SERVER}, include a controller user, for example:
 +
 [source]
 ----

--- a/docs/product-installation-guide/src/main/asciidoc/install-dc-standalone-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/install-dc-standalone-proc.adoc
@@ -1,8 +1,7 @@
 [id='install-dc-standalone-proc']
 = Installing standalone {CENTRAL} 
 
-You can use the {CENTRAL} standalone JAR file to install {CENTRAL} on an application server other than {EAP}. This installation method does not require a separate server installation.
-
+You can use the {CENTRAL} standalone JAR file to run {CENTRAL} without needing to deploy it to an application server, for example {EAP}. 
 [NOTE]
 ====
 Red Hat only supports this installation type when it is installed on premise, on Red Hat Enterprise Linux.
@@ -31,7 +30,25 @@ swarm:
         properties-authorization:
           path: /path/to/application-roles.properties
 ----
-Enter the following command:
+. Create the `application-users.properties` file. Include an adminitrative user and if this {CENTRAL} instance will be a controller for {KIE_SERVER}, include a controller user, for example:
++
+[source]
+----
+rhdmAdmin=password1
+controllerUser=controllerUser1234
+----
++
+. Create the `application-roles.properties` file to assign roles to the users that you included in the `application-users.properties` file, for example:
++
+[source]
+----
+rhdmAdmin=admin
+controllerUser=rest-all
+----
++
+For more information, see <<dm-roles-con>>.
+
+. Enter the following command:
 +
 [source]
 ----

--- a/docs/product-installation-guide/src/main/asciidoc/install-dc-standalone-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/install-dc-standalone-proc.adoc
@@ -67,5 +67,18 @@ java -jar rhdm-7.0.0.GA-decision-central-standalone.jar -s
 application-config.yaml -D<property>=<value> -D<property>=<value>
 ----
 
+//For example:
+//* To run {CENTRAL} and connect to {KIE_SERVER} as the user `controllerUser`, enter:
+//+
+//[source]
+//----
+//java -jar rhdm-7.0.0.GA-decision-central-standalone.jar \
+// -s application-config.yaml \
+// -Dorg.kie.server.user=controllerUser
+// -Dorg.kie.server.pwd=controllerUser1234
+//----
+//+
+//Doing this enables you to deploy containers to {KIE_SERVER}.
 See <<install-standalone-properties-con>> for more information.
+
 

--- a/docs/product-installation-guide/src/main/asciidoc/install-download-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/install-download-proc.adoc
@@ -18,7 +18,7 @@ Depending on your environment and installation requirements, download the {PRODU
 .Next steps
 Go to one of the following sections:
 
-* <<install-dc-standalone-proc>>
+* <<run-dc-standalone-proc>>
 * <<assembly_installing-using-installer>>
 * <<assembly_installing-on-eap-deployable>>
 

--- a/docs/product-installation-guide/src/main/asciidoc/install-standalone-properties-con.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/install-standalone-properties-con.adoc
@@ -1,6 +1,6 @@
 [id='install-standalone-properties-con']
 = Supported properties
-When you install standalone {KIE_SERVER}, you can use the properties listed in this section in the following command:
+When you install standalone {CENTRAL}, you can use the properties listed in this section in the following command:
 [source] 
 ----
 rhdm-7.0.0.GA-decision-central-standalone.jar -s application-config.yaml -D<property>=<value> -D<property>=<value>
@@ -35,4 +35,6 @@ If you plan to use RSA or any algorithm other than DSA, make sure you setup prop
 * `org.kie.demo`: Enables external clone of a demo application from GitHub.
 * `org.kie.build.disable-project-explorer`: Disable automatic build of selected Project in Project Explorer. Default: false
 * `org.kie.verification.disable-dtable-realtime-verification`: Disables the realtime validation and verification of decision tables. Default: false
-* `org.kie.server.controller`: URL for connecting with a Kie Server Controller, for example: `org.kie.server.controller - ws://localhost:8080/decision-central/websocket/controller.
+* `org.kie.server.controller`: URL for connecting with a Kie Server Controller, for example: `org.kie.server.controller` - `ws://localhost:8080/decision-central/websocket/controller`.
+* `org.kie.server.user`: User name used to connect with the {KIE_SERVER} nodes from the controller. This property is only required when using this {CENTRAL} installation as a controller.
+* `org.kie.server.pwd`: Password used to connect with the {KIE_SERVER} nodes from the controller. This property is only required when using this {CENTRAL} installation as a controller.

--- a/docs/product-installation-guide/src/main/asciidoc/install-standalone-properties-con.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/install-standalone-properties-con.adoc
@@ -1,5 +1,12 @@
 [id='install-standalone-properties-con']
 = Supported properties
+When you install standalone {KIE_SERVER}, you can use the properties listed in this section in the following command:
+[source] 
+----
+rhdm-7.0.0.GA-decision-central-standalone.jar -s application-config.yaml -D<property>=<value> -D<property>=<value>
+----
+In this command, `<property>` is a property from the following list and `<value>` is a value that you assign to that property.
+
 * `org.uberfire.nio.git.dir`: Location of the directory .niogit. Default: working directory
 * `org.uberfire.nio.git.dirname`: Name of the git directory. Default: .niogit
 * `org.uberfire.nio.git.daemon.enabled`: Enables/disables git daemon. Default: true
@@ -17,11 +24,6 @@
 If you plan to use RSA or any algorithm other than DSA, make sure you setup properly your Application Server to use Bouncy Castle JCE library.
 ====
 * `org.uberfire.metadata.index.dir`: Place where Lucene .index folder will be stored. Default: working directory
-* `org.uberfire.cluster.id`: Name of the helix cluster, for example: kie-cluster
-* `org.uberfire.cluster.zk`: Connection string to zookeeper. This is of the form host1:port1,host2:port2,host3:port3, for example: localhost:2188
-* `org.uberfire.cluster.local.id`: Unique id of the helix cluster node, note that ‘`:`’ is replaced with ‘`\_`’, for example: node1_12345
-* `org.uberfire.cluster.vfs.lock`: Name of the resource defined on helix cluster, for example: kie-vfs
-* `org.uberfire.cluster.autostart`: Delays VFS clustering until the application is fully initialized to avoid conflicts when all cluster members create local clones. Default: false
 * `org.uberfire.ldap.regex.role_mapper`: Regex pattern used to map LDAP principal names to application role name. Note that the variable role must be part of the pattern as it is substited by the application role name when matching a principal value to role name. Default: Not used.
 * `org.uberfire.sys.repo.monitor.disabled`: Disable configuration monitor (do not disable unless you know what you’re doing). Default: false
 * `org.uberfire.secure.key`: Secret password used by password encryption. Default`: org.uberfire.admin
@@ -29,9 +31,8 @@ If you plan to use RSA or any algorithm other than DSA, make sure you setup prop
 * `org.uberfire.domain`: security-domain name used by uberfire. Default: ApplicationRealm
 * `org.guvnor.m2repo.dir`: Place where Maven repository folder will be stored. Default: working-directory/repositories/kie
 * `org.guvnor.project.gav.check.disabled`: Disable GAV checks. Default: false
-* `org.kie.example.repositories`: Folder from where demo repositories will be cloned. The demo repositories need to have been obtained and placed in this folder. Demo repositories can be obtained from the kie-wb-6.2.0-SNAPSHOT-example-repositories.zip artifact. This System Property takes precedence over org.kie.demo and org.kie.example. Default: Not used.
-* `org.kie.demo`: Enables external clone of a demo application from GitHub. This System Property takes precedence over org.kie.example. Default: true
-* `org.kie.example`: Enables example structure composed by Repository, Organization Unit and Project. Default: false
+* `org.kie.example`: Enables external clone of a demo application from GitHub.
+* `org.kie.demo`: Enables external clone of a demo application from GitHub.
 * `org.kie.build.disable-project-explorer`: Disable automatic build of selected Project in Project Explorer. Default: false
 * `org.kie.verification.disable-dtable-realtime-verification`: Disables the realtime validation and verification of decision tables. Default: false
-* `org.kie.workbench.controller`: URL for connecting with a Kie Server Controller, for example: `ws://localhost:8080/kie-server-controller/websocket/controller`.
+* `org.kie.server.controller`: URL for connecting with a Kie Server Controller, for example: `org.kie.server.controller - ws://localhost:8080/decision-central/websocket/controller.

--- a/docs/product-installation-guide/src/main/asciidoc/run-dc-standalone-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/run-dc-standalone-proc.adoc
@@ -1,5 +1,5 @@
-[id='install-dc-standalone-proc']
-= Installing standalone {CENTRAL} 
+[id='run-dc-standalone-proc']
+= Running standalone {CENTRAL} 
 
 You can use the {CENTRAL} standalone JAR file to run {CENTRAL} without needing to deploy it to an application server, for example {EAP}. 
 [NOTE]
@@ -47,7 +47,7 @@ controllerUser=controllerUser1234
 [source]
 ----
 rhdmAdmin=admin
-controllerUser=rest-all
+controllerUser=kie-server
 ----
 +
 For more information, see <<dm-roles-con>>.
@@ -59,14 +59,15 @@ For more information, see <<dm-roles-con>>.
 java -jar rhdm-7.0.0.GA-decision-central-standalone.jar -s
 application-config.yaml
 ----
-
-In addition, you can set any properties supported by {CENTRAL} by including the `-D<property>=<value>` parameter in the installation command, for example:
++
+In addition, you can set any properties supported by {CENTRAL} by including the `-D<property>=<value>` parameter in this command, for example:
++
 [source]
 ----
 java -jar rhdm-7.0.0.GA-decision-central-standalone.jar -s
 application-config.yaml -D<property>=<value> -D<property>=<value>
 ----
-
++
 //For example:
 //* To run {CENTRAL} and connect to {KIE_SERVER} as the user `controllerUser`, enter:
 //+
@@ -79,6 +80,6 @@ application-config.yaml -D<property>=<value> -D<property>=<value>
 //----
 //+
 //Doing this enables you to deploy containers to {KIE_SERVER}.
-See <<install-standalone-properties-con>> for more information.
+See <<run-standalone-properties-con>> for more information.
 
 

--- a/docs/product-installation-guide/src/main/asciidoc/run-dc-standalone-proc.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/run-dc-standalone-proc.adoc
@@ -1,10 +1,10 @@
 [id='run-dc-standalone-proc']
 = Running standalone {CENTRAL} 
 
-You can use the {CENTRAL} standalone JAR file to run {CENTRAL} without needing to deploy it to an application server, for example {EAP}. 
+You can use the {CENTRAL} standalone JAR file to run {CENTRAL} without needing to deploy it to an application server such as {EAP}. 
 [NOTE]
 ====
-Red Hat only supports this installation type when it is installed on premise, on Red Hat Enterprise Linux.
+Red Hat supports this installation type only when it is installed on premise, on Red Hat Enterprise Linux.
 //Any particular version of RHEL?
 ====
 

--- a/docs/product-installation-guide/src/main/asciidoc/run-standalone-properties-con.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/run-standalone-properties-con.adoc
@@ -1,4 +1,4 @@
-[id='install-standalone-properties-con']
+[id='run-standalone-properties-con']
 = Supported properties
 When you install standalone {CENTRAL}, you can use the properties listed in this section in the following command:
 [source] 
@@ -32,9 +32,8 @@ If you plan to use RSA or any algorithm other than DSA, make sure you setup prop
 * `org.guvnor.m2repo.dir`: Place where Maven repository folder will be stored. Default: working-directory/repositories/kie
 * `org.guvnor.project.gav.check.disabled`: Disable GAV checks. Default: false
 * `org.kie.example`: Enables external clone of a demo application from GitHub.
-* `org.kie.demo`: Enables external clone of a demo application from GitHub.
 * `org.kie.build.disable-project-explorer`: Disable automatic build of selected Project in Project Explorer. Default: false
 * `org.kie.verification.disable-dtable-realtime-verification`: Disables the realtime validation and verification of decision tables. Default: false
-* `org.kie.server.controller`: URL for connecting with a Kie Server Controller, for example: `org.kie.server.controller` - `ws://localhost:8080/decision-central/websocket/controller`.
+* `org.kie.server.controller`: URL for connecting with a Kie Server Controller, for example: `ws://localhost:8080/decision-central/websocket/controller`.
 * `org.kie.server.user`: User name used to connect with the {KIE_SERVER} nodes from the controller. This property is only required when using this {CENTRAL} installation as a controller.
 * `org.kie.server.pwd`: Password used to connect with the {KIE_SERVER} nodes from the controller. This property is only required when using this {CENTRAL} installation as a controller.

--- a/docs/product-installation-guide/src/main/asciidoc/run-standalone-properties-con.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/run-standalone-properties-con.adoc
@@ -3,7 +3,7 @@
 When you install standalone {CENTRAL}, you can use the properties listed in this section in the following command:
 [source] 
 ----
-rhdm-7.0.0.GA-decision-central-standalone.jar -s application-config.yaml -D<property>=<value> -D<property>=<value>
+java -jar rhdm-7.0.0.GA-decision-central-standalone.jar -s application-config.yaml -D<property>=<value> -D<property>=<value>
 ----
 In this command, `<property>` is a property from the following list and `<value>` is a value that you assign to that property.
 

--- a/docs/product-installation-guide/src/main/asciidoc/run-standalone-properties-con.adoc
+++ b/docs/product-installation-guide/src/main/asciidoc/run-standalone-properties-con.adoc
@@ -5,35 +5,35 @@ When you install standalone {CENTRAL}, you can use the properties listed in this
 ----
 java -jar rhdm-7.0.0.GA-decision-central-standalone.jar -s application-config.yaml -D<property>=<value> -D<property>=<value>
 ----
-In this command, `<property>` is a property from the following list and `<value>` is a value that you assign to that property.
+In this command, `<property>` is a property from the following list and `<value>` is a value that you assign to that property:
 
-* `org.uberfire.nio.git.dir`: Location of the directory .niogit. Default: working directory
-* `org.uberfire.nio.git.dirname`: Name of the git directory. Default: .niogit
-* `org.uberfire.nio.git.daemon.enabled`: Enables/disables git daemon. Default: true
-* `org.uberfire.nio.git.daemon.host`: If git daemon enabled, uses this property as local host identifier. Default`: localhost
-* `org.uberfire.nio.git.daemon.port`: If git daemon enabled, uses this property as port number. Default: 9418
-* `org.uberfire.nio.git.ssh.enabled`: Enables/disables ssh daemon. Default: true
-* `org.uberfire.nio.git.ssh.host`: If ssh daemon enabled, uses this property as local host identifier. Default: localhost
-* `org.uberfire.nio.git.ssh.port`: If ssh daemon enabled, uses this property as port number. Default: 8001
-* `org.uberfire.nio.git.ssh.cert.dir`: Location of the directory .security where local certificates will be stored. Default: working directory
-* `org.uberfire.nio.git.ssh.passphrase`: Passphrase to access your Operating Systems public keystore when cloning git repositories with scp style URLs; e.g. git@github.com:user/repository.git.
-* `org.uberfire.nio.git.ssh.algorithm`: Algorithm used by SSH. Default: DSA
+* `org.uberfire.nio.git.dir`: Location of the directory `.niogit`. Default: working directory
+* `org.uberfire.nio.git.dirname`: Name of the git directory. Default: `.niogit`
+* `org.uberfire.nio.git.daemon.enabled`: Enables or disables the git daemon. Default: `true`
+* `org.uberfire.nio.git.daemon.host`: If the git daemon is enabled, uses this property as the local host identifier. Default: `localhost`
+* `org.uberfire.nio.git.daemon.port`: If the git daemon is enabled, uses this property as the port number. Default: `9418`
+* `org.uberfire.nio.git.ssh.enabled`: Enables or disables the SSH daemon. Default: `true`
+* `org.uberfire.nio.git.ssh.host`: If the SSH daemon enabled, uses this property as the local host identifier. Default: `localhost`
+* `org.uberfire.nio.git.SSH.port`: If the SSH daemon is enabled, uses this property as the port number. Default: `8001`
+* `org.uberfire.nio.git.ssh.cert.dir`: Location of the directory `.security` where local certificates will be stored. Default: working directory
+* `org.uberfire.nio.git.ssh.passphrase`: Pass phrase to access the public key store of your operating system when cloning git repositories with SCP style URLs. Example: git@github.com:user/repository.git.
+* `org.uberfire.nio.git.ssh.algorithm`: Algorithm used by SSH. Default: `DSA`
 +
 [NOTE]
 ====
-If you plan to use RSA or any algorithm other than DSA, make sure you setup properly your Application Server to use Bouncy Castle JCE library.
+If you plan to use RSA or any algorithm other than DSA, make sure you set up your application server to use the Bouncy Castle JCE library.
 ====
-* `org.uberfire.metadata.index.dir`: Place where Lucene .index folder will be stored. Default: working directory
-* `org.uberfire.ldap.regex.role_mapper`: Regex pattern used to map LDAP principal names to application role name. Note that the variable role must be part of the pattern as it is substited by the application role name when matching a principal value to role name. Default: Not used.
-* `org.uberfire.sys.repo.monitor.disabled`: Disable configuration monitor (do not disable unless you know what you’re doing). Default: false
-* `org.uberfire.secure.key`: Secret password used by password encryption. Default`: org.uberfire.admin
-* `org.uberfire.secure.alg`: Crypto algorithm used by password encryption. Default: PBEWithMD5AndDES
-* `org.uberfire.domain`: security-domain name used by uberfire. Default: ApplicationRealm
-* `org.guvnor.m2repo.dir`: Place where Maven repository folder will be stored. Default: working-directory/repositories/kie
-* `org.guvnor.project.gav.check.disabled`: Disable GAV checks. Default: false
+* `org.uberfire.metadata.index.dir`: Place where the Lucene `.index` folder will be stored. Default: working directory
+* `org.uberfire.ldap.regex.role_mapper`: Regex pattern used to map LDAP principal names to application role name. Note that the variable role must be part of the pattern as it is substited by the application role name when matching a principal value to a role name. Default: Not used.
+* `org.uberfire.sys.repo.monitor.disabled`: Disables the configuration monitor Note: Do not disable unless you are confident that you should do so. Default: `false`
+* `org.uberfire.secure.key`: Secret password used by password encryption. Default`: `org.uberfire.admin`
+* `org.uberfire.secure.alg`: Crypto algorithm used by password encryption. Default: `PBEWithMD5AndDES`
+* `org.uberfire.domain`: The security-domain name used by uberfire. Default: `ApplicationRealm`
+* `org.guvnor.m2repo.dir`: The place where the Maven repository folder will be stored. Default: `_working-directory_`/repositories/kie
+* `org.guvnor.project.gav.check.disabled`: Disables GAV checks. Default: `false`
 * `org.kie.example`: Enables external clone of a demo application from GitHub.
-* `org.kie.build.disable-project-explorer`: Disable automatic build of selected Project in Project Explorer. Default: false
-* `org.kie.verification.disable-dtable-realtime-verification`: Disables the realtime validation and verification of decision tables. Default: false
-* `org.kie.server.controller`: URL for connecting with a Kie Server Controller, for example: `ws://localhost:8080/decision-central/websocket/controller`.
+* `org.kie.build.disable-project-explorer`: Disables automatic build of selected project in Project Explorer. Default: `false`
+* `org.kie.verification.disable-dtable-realtime-verification`: Disables the realtime validation and verification of guided decision tables. Default: `false`
+* `org.kie.server.controller`: URL for connecting with a Kie Server controller, for example: `ws://localhost:8080/decision-central/websocket/controller`.
 * `org.kie.server.user`: User name used to connect with the {KIE_SERVER} nodes from the controller. This property is only required when using this {CENTRAL} installation as a controller.
 * `org.kie.server.pwd`: Password used to connect with the {KIE_SERVER} nodes from the controller. This property is only required when using this {CENTRAL} installation as a controller.


### PR DESCRIPTION
The rendered doc is [here](http://file.ork.redhat.com/~emmurphy/BXMSDOC-2222a/#install-dc-standalone-proc).

I updated with comments in the jira, and I demoted the section to after Installing on EAP. 