### PR TITLE
BXMSDOC-2274-7.11 Tomcat installation misses 'datadesignerobject' setting

### DIFF
--- a/doc-content/enterprise-only/installation/run-standalone-properties-con.adoc
+++ b/doc-content/enterprise-only/installation/run-standalone-properties-con.adoc
@@ -43,3 +43,12 @@ If you plan to use RSA or any algorithm other than DSA, make sure you set up you
 * `org.kie.server.controller`: URL for connecting with a {CONTROLLER}, for example: `ws://localhost:8080/{URL_COMPONENT_CENTRAL}/websocket/controller`
 * `org.kie.server.user`: User name used to connect with the {KIE_SERVER} nodes from the {CONTROLLER}. This property is only required when using this {CENTRAL} installation as a {CONTROLLER}.
 * `org.kie.server.pwd`: Password used to connect with the {KIE_SERVER} nodes from the {CONTROLLER}. This property is only required when using this {CENTRAL} installation as a {CONTROLLER}.
++
+[NOTE]
+====
+Use this property for {CENTRAL} only. If you share a runtime environment with any other component, isolate the configuration and apply it only to {CENTRAL}.
+====
+* `org.uberfire.gzip.enable`: Enables or disables Gzip compression on GzipFilter. Default: `true`
+ifeval::["{context}" == "install-on-jws"]
+* `designerdataobjects`: Disables the data object functionality. Set the value of this parameter to `false`.
+endif::[]


### PR DESCRIPTION
[RHDM 7.1 draft](http://file.ork.redhat.com/~emmurphy/BXMSDOC-2274-7.1-dm/#run-standalone-properties-con)
[RHPAM 7.2 draft](http://file.ork.redhat.com/~emmurphy/BXMSDOC-2274-7.1-pam/#run-standalone-properties-con)