### PR TITLE
BXMSDOC-7455 added section on disabling HTTP with TLS

### DIFF
--- a/doc-content/enterprise-only/admin-and-config/kie-server-smart-router-enable-tls-support-proc.adoc
+++ b/doc-content/enterprise-only/admin-and-config/kie-server-smart-router-enable-tls-support-proc.adoc
@@ -1,7 +1,7 @@
 [id='kie-server-smart-router-enable-tls-support-proc_{context}']
 = Configuring Smart Router for TLS support
 
-You can configure Smart Router (KIE Server Router) for Transport Layer Security (TLS) support to allow HTTPS traffic. In addition, you can disable non-secure HTTP connections to Smart Router.
+You can configure Smart Router (KIE Server Router) for Transport Layer Security (TLS) support to allow HTTPS traffic. In addition, you can disable unsecure HTTP connections to Smart Router.
 
 .Prerequisites
 * {KIE_SERVER} is installed on each node of a {EAP} {EAP_VERSION} cluster.
@@ -14,7 +14,7 @@ xref:clustering-smart-router-install-proc_clustering-runtime-standalone[].
 endif::[]
 
 .Procedure
-Use one of the following methods to start Smart Router:
+To start Smart Router, use one of the following methods:
 
 * To start Smart Router with TLS support and HTTPS enabled as well as allowing HTTP connections, enter the following command:
 +
@@ -46,6 +46,6 @@ java  -Dorg.kie.server.router.tls.keystore = <KEYSTORE_PATH>
       -jar rhpam-7.9.0-smart-router.jar
 ----
 +
-When the `org.kie.server.router.port` system property is set to `0` or less, then the HTTP listener is not registered. If TLS is configured then Smart Router listens only on HTTPS port.
+When the `org.kie.server.router.port` system property is set to `0`, then the HTTP listener is not registered. If TLS is configured and the HTTP listener is not registered, then Smart Router listens only on the HTTPS port.
 +
 NOTE:  If TLS is not configured and you disable HTTP by setting `org.kie.server.router.port` to `0`, then an error occurs and Smart Router stops.

--- a/doc-content/enterprise-only/admin-and-config/kie-server-smart-router-enable-tls-support-proc.adoc
+++ b/doc-content/enterprise-only/admin-and-config/kie-server-smart-router-enable-tls-support-proc.adoc
@@ -1,7 +1,7 @@
 [id='kie-server-smart-router-enable-tls-support-proc_{context}']
 = Configuring Smart Router for TLS support
 
-You can configure Smart Router (KIE Server Router) for TLS support to allow HTTPS traffic.
+You can configure Smart Router (KIE Server Router) for Transport Layer Security (TLS) support to allow HTTPS traffic. In addition, you can disable non-secure HTTP connections to Smart Router.
 
 .Prerequisites
 * {KIE_SERVER} is installed on each node of a {EAP} {EAP_VERSION} cluster.
@@ -14,15 +14,38 @@ xref:clustering-smart-router-install-proc_clustering-runtime-standalone[].
 endif::[]
 
 .Procedure
-* To start Smart Router with TLS support and HTTPS enabled, use the TLS keystore properties, for example:
+Use one of the following methods to start Smart Router:
+
+* To start Smart Router with TLS support and HTTPS enabled as well as allowing HTTP connections, enter the following command:
 +
 [source,java]
 ----
 java  -Dorg.kie.server.router.tls.keystore = <KEYSTORE_PATH>
-      -Dorg.kie.server.router.tls.keystore.password = <KEYSTORE_PWD>
+      -Dorg.kie.server.router.tls.keystore.password = <KEYSTORE_PASSWORD>
       -Dorg.kie.server.router.tls.keystore.keyalias = <KEYSTORE_ALIAS>
       -Dorg.kie.server.router.tls.port = <HTTPS_PORT>
       -jar rhpam-7.9.0-smart-router.jar
 ----
 +
-`org.kie.server.router.tls.port` is a property used to configure the HTTPS port. The default HTTPS port value is `9443`.
+In this example, replace the following variables:
+
+* `<KEYSTORE_PATH>`: The path where the keystore will be stored.
+* `<KEYSTORE_PASSWORD>`: The keystore password.
+* `<AKEYSTORE_ALIAS>`: The password used to access values stored with the alias.
+* `<HTTPS_PORT>`: The HTTPS port. The default HTTPS port is `9443`.
++
+* To start Smart Router with TLS support and HTTPS enabled and with HTTP connections disabled, enter the following command:
++
+[source,java]
+----
+java  -Dorg.kie.server.router.tls.keystore = <KEYSTORE_PATH>
+      -Dorg.kie.server.router.tls.keystore.password = <KEYSTORE_PASSWORD>
+      -Dorg.kie.server.router.tls.keystore.keyalias = <KEYSTORE_ALIAS>
+      -Dorg.kie.server.router.tls.port = <HTTPS_PORT>
+      -Dorg.kie.server.router.port=0
+      -jar rhpam-7.9.0-smart-router.jar
+----
++
+When the `org.kie.server.router.port` system property is set to `0` or less, then the HTTP listener is not registered. If TLS is configured then Smart Router listens on HTTPS port.
++
+NOTE:  If TLS is not configured and you disable HTTP by setting `org.kie.server.router.port` to `0`, then an error occurs and Smart Router stops.

--- a/doc-content/enterprise-only/admin-and-config/kie-server-smart-router-enable-tls-support-proc.adoc
+++ b/doc-content/enterprise-only/admin-and-config/kie-server-smart-router-enable-tls-support-proc.adoc
@@ -31,7 +31,7 @@ In this example, replace the following variables:
 
 * `<KEYSTORE_PATH>`: The path where the keystore will be stored.
 * `<KEYSTORE_PASSWORD>`: The keystore password.
-* `<AKEYSTORE_ALIAS>`: The password used to access values stored with the alias.
+* `<KEYSTORE_ALIAS>`: The alias name used to store the certificate.
 * `<HTTPS_PORT>`: The HTTPS port. The default HTTPS port is `9443`.
 +
 * To start Smart Router with TLS support and HTTPS enabled and with HTTP connections disabled, enter the following command:
@@ -46,6 +46,6 @@ java  -Dorg.kie.server.router.tls.keystore = <KEYSTORE_PATH>
       -jar rhpam-7.9.0-smart-router.jar
 ----
 +
-When the `org.kie.server.router.port` system property is set to `0` or less, then the HTTP listener is not registered. If TLS is configured then Smart Router listens on HTTPS port.
+When the `org.kie.server.router.port` system property is set to `0` or less, then the HTTP listener is not registered. If TLS is configured then Smart Router listens only on HTTPS port.
 +
 NOTE:  If TLS is not configured and you disable HTTP by setting `org.kie.server.router.port` to `0`, then an error occurs and Smart Router stops.


### PR DESCRIPTION
[BXMSDOC-7455](https://issues.redhat.com/browse/BXMSDOC-7455)
[RHPAM draft](http://file.ork.redhat.com/~emmurphy/BXMSDOC-BXMSDOC-7455-pam/#kie-server-smart-router-enable-tls-support-proc_clustering-runtime-standalone)
No impact on RHDM