### PR TITLE
BXMSDOC-8653 baseFilter(AUTH_LDAP_BASE_FILTER) is incompatible with versions earlier than 7.12.0

### DIFF
--- a/doc-content/enterprise-only/openshift/operator-deploy-security-proc.adoc
+++ b/doc-content/enterprise-only/openshift/operator-deploy-security-proc.adoc
@@ -15,7 +15,7 @@ After you set the basic configuration of a {PRODUCT} environment using {operator
 ** `Internal`: You configure the initial administration user when deploying the environment. You can create a post-configuration script to add users in the Elytron security subsystem. For instructions about creating a post-configuration script, see xref:jboss-postconfigure-proc_{context}[].
 ** `RH-SSO`: {PRODUCT} uses {RH-SSO} for authentication.
 ** `LDAP`: {PRODUCT} uses LDAP for authentication
-. Complete the security configuration based on the *Authentication mode* that you selected.
+. Complete the security configuration based on the *Authentication mode* that you selected:
 +
 --
 
@@ -29,6 +29,10 @@ If you selected `RH-SSO`, configure RH-SSO authentication:
 
 If you selected `LDAP`, configure LDAP authentication:
 
+[IMPORTANT]
+====
+The `baseFilter` field is a legacy LDAP search filter used to locate the context of the user to authenticate. The input `username` or `userDN` obtained from the login module callback is substituted into the filter anywhere a `{0}` expression is used. A common example for the search filter is `(uid={0})`. For Elytron based subsystems, this property should be configured only with the search filter parameter, without any search expression. For example, search for `uid` instead of `(uid={0})`.
+====
 .. In the *LDAP URL* field, enter the LDAP URL.
 .. Set LDAP parameters. These parameters configure LDAP authentication using the Elytron subsystem of {EAP}. For more information about using the Elytron subsystem of {EAP} with LDAP, see https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/{EAP_VERSION}/html/how_to_configure_identity_management/elytron_secure_apps#elytron_ldap_auth_app[Configure Authentication with an LDAP-Based Identity Store].
 +


### PR DESCRIPTION
[PAM HTML](http://file.ork.redhat.com/~emmurphy/BXMSDOC-8653-pam/#operator-deploy-security-proc_openshift-operator)

DM HTML
http://file.ork.redhat.com/~emmurphy/BXMSDOC-8653-dm/#operator-deploy-security-proc_openshift-operator

